### PR TITLE
feat(monitoring): migrate grafana to ssd

### DIFF
--- a/prometheus-stack/kustomization.yaml
+++ b/prometheus-stack/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - resources/grafana-pvc.yaml
   - resources/namespace.yaml
 
 helmCharts:
@@ -83,6 +84,7 @@ helmCharts:
               secretName: grafana-tls
         persistence:
           enabled: true
+          existingClaim: grafana-data
         deploymentStrategy:
           type: Recreate
       prometheus:

--- a/prometheus-stack/resources/grafana-pvc.yaml
+++ b/prometheus-stack/resources/grafana-pvc.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-data
+spec:
+  storageClassName: ceph-ssd
+  dataSource:
+    name: grafana-migration-20250823
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/ssd-migration-20250823/base/kustomization.yaml
+++ b/ssd-migration-20250823/base/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: monitoring
+nameSuffix: "-20250823"
+
+resources:
+  - resources/grafana-volume-snapshot.yaml

--- a/ssd-migration-20250823/base/resources/grafana-volume-snapshot.yaml
+++ b/ssd-migration-20250823/base/resources/grafana-volume-snapshot.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: grafana-migration
+spec:
+  volumeSnapshotClassName: ceph-block
+  source:
+    persistentVolumeClaimName: prometheus-stack-grafana


### PR DESCRIPTION
Migrate grafana PVC to ceph-ssd storage class.

- create volume snapshot to copy data
- create new pvc based on volume snapshot