### PR TITLE
Revert "chore(deps): update helm release rook-ceph-cluster to v1.18.3"

### DIFF
--- a/applications/rook-ceph-cluster.yaml
+++ b/applications/rook-ceph-cluster.yaml
@@ -9,7 +9,7 @@ spec:
   source:
     chart: rook-ceph-cluster
     repoURL: https://charts.rook.io/release
-    targetRevision: v1.18.3
+    targetRevision: v1.18.2
     helm:
       valuesObject:
         ingress:


### PR DESCRIPTION
Reverts adborden/k8s-lab#208

Issue with nil image value.